### PR TITLE
feat: allow language selection via URL parameter

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,8 +145,11 @@ if (mobileMenuButton && closeMobileMenuButton && mobileMenu) {
 const getPreferredLanguage = () => {
   const urlParams = new URLSearchParams(window.location.search);
   const langParam = urlParams.get('lang');
-  if (langParam && translations[langParam]) {
-    return langParam;
+  if (langParam) {
+    const baseLang = langParam.split('-')[0];
+    if (translations[baseLang]) {
+      return baseLang;
+    }
   }
 
   const saved = localStorage.getItem('preferred-lang');


### PR DESCRIPTION
This commit modifies the `getPreferredLanguage` function in `js/main.js` to prioritize the `lang` query parameter (e.g., `?lang=pt` or `?lang=en`) when determining the initial language. This allows users to share links in a specific language.

If the URL parameter is present and valid, it overrides the value in `localStorage` and the browser's default language. If it is missing or invalid, the logic falls back to the existing behavior.